### PR TITLE
Add stop command to end recordings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { Client, GatewayIntentBits } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
-const { joinAndRecord } = require('./voiceRecorder');
+const { joinAndRecord, stopRecording } = require('./voiceRecorder');
 const { transcribeAudio } = require('./transcribe');
 require('dotenv').config();
 
@@ -27,6 +27,11 @@ client.on('messageCreate', async (message) => {
     }
     joinAndRecord(message.member.voice.channel);
     message.reply('Recording started.');
+  }
+
+  if (message.content === '!stop') {
+    stopRecording();
+    message.reply('Recording stopped.');
   }
 
   if (message.content === '!transcribe') {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,5 @@
 jest.mock('fs');
-jest.mock('../voiceRecorder', () => ({ joinAndRecord: jest.fn() }));
+jest.mock('../voiceRecorder', () => ({ joinAndRecord: jest.fn(), stopRecording: jest.fn() }));
 jest.mock('../transcribe', () => ({ transcribeAudio: jest.fn().mockResolvedValue('text') }));
 
 jest.mock('discord.js', () => {
@@ -23,11 +23,11 @@ jest.mock('discord.js', () => {
   };
 });
 
-let joinAndRecord, transcribeAudio;
+let joinAndRecord, stopRecording, transcribeAudio;
 let Client, GatewayIntentBits, __mocks, onceMock, onMock, loginMock;
 ({ Client, GatewayIntentBits, __mocks } = require('discord.js'));
 ({ onceMock, onMock, loginMock } = __mocks);
-({ joinAndRecord } = require('../voiceRecorder'));
+({ joinAndRecord, stopRecording } = require('../voiceRecorder'));
 ({ transcribeAudio } = require('../transcribe'));
 
 let fs = require('fs');
@@ -38,7 +38,7 @@ describe('index', () => {
     jest.resetModules();
     ({ Client, GatewayIntentBits, __mocks } = require('discord.js'));
     ({ onceMock, onMock, loginMock } = __mocks);
-    ({ joinAndRecord } = require('../voiceRecorder'));
+    ({ joinAndRecord, stopRecording } = require('../voiceRecorder'));
     ({ transcribeAudio } = require('../transcribe'));
     fs = require('fs');
     jest.clearAllMocks();
@@ -83,5 +83,17 @@ describe('index', () => {
     const expectedPath = path.join(__dirname, '..', 'recordings', 'user-1.wav');
     expect(transcribeAudio).toHaveBeenCalledWith(expectedPath);
     expect(reply).toHaveBeenCalledWith('Transcription: text');
+  });
+
+  test('handles !stop command', async () => {
+    require('../index');
+    const handler = onMock.mock.calls.find(c => c[0] === 'messageCreate')[1];
+    const reply = jest.fn();
+    const msg = { content: '!stop', author: { bot: false }, reply, member: {} };
+
+    await handler(msg);
+
+    expect(stopRecording).toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith('Recording stopped.');
   });
 });

--- a/voiceRecorder.js
+++ b/voiceRecorder.js
@@ -8,12 +8,16 @@ if (ffmpegPath) {
 }
 const path = require('path');
 
+let activeConnection = null;
+
 function joinAndRecord(channel) {
   const connection = joinVoiceChannel({
     channelId: channel.id,
     guildId: channel.guild.id,
     adapterCreator: channel.guild.voiceAdapterCreator,
   });
+
+  activeConnection = connection;
 
   const receiver = connection.receiver;
 
@@ -48,4 +52,11 @@ function joinAndRecord(channel) {
   });
 }
 
-module.exports = { joinAndRecord };
+function stopRecording() {
+  if (activeConnection) {
+    activeConnection.destroy();
+    activeConnection = null;
+  }
+}
+
+module.exports = { joinAndRecord, stopRecording };


### PR DESCRIPTION
## Summary
- allow `!stop` command in `index.js` to end recordings
- expose `stopRecording` cleanup helper in `voiceRecorder.js`
- test new stop logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444e2a700c832e8e2ce4053024a792