### PR TITLE
Improve error handling for transcription API

### DIFF
--- a/tests/transcribe.test.js
+++ b/tests/transcribe.test.js
@@ -24,4 +24,14 @@ describe('transcribeAudio', () => {
 
     fs.unlinkSync(file);
   });
+
+  test('throws an error when API request fails', async () => {
+    const file = path.join(__dirname, 'temp.wav');
+    fs.writeFileSync(file, 'data');
+    axios.post.mockRejectedValue(new Error('network'));
+
+    await expect(transcribeAudio(file)).rejects.toThrow('Transcription API request failed');
+
+    fs.unlinkSync(file);
+  });
 });

--- a/transcribe.js
+++ b/transcribe.js
@@ -7,18 +7,24 @@ async function transcribeAudio(filePath) {
   formData.append('file', fs.createReadStream(filePath));
   formData.append('model', 'whisper-1');
 
-  const response = await axios.post(
-    'https://api.openai.com/v1/audio/transcriptions',
-    formData,
-    {
-      headers: {
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
-        ...formData.getHeaders(),
-      },
-    }
-  );
+  try {
+    const response = await axios.post(
+      'https://api.openai.com/v1/audio/transcriptions',
+      formData,
+      {
+        headers: {
+          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+          ...formData.getHeaders(),
+        },
+      }
+    );
 
-  return response.data.text;
+    return response.data.text;
+  } catch (err) {
+    const msg = err.response?.data || err.message || err;
+    console.error('Failed to transcribe audio:', msg);
+    throw new Error('Transcription API request failed');
+  }
 }
 
 module.exports = { transcribeAudio };


### PR DESCRIPTION
## Summary
- improve `transcribeAudio` error handling by wrapping the axios request in a try/catch
- propagate failures with a descriptive error
- add unit test covering failed API requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684450298558832ea0d25dbae1ef5b2f